### PR TITLE
add keyrings dir

### DIFF
--- a/items.py
+++ b/items.py
@@ -31,6 +31,11 @@ directories = {
         "owner": "root",
         "group": "root",
     },
+    "/etc/apt/keyrings": {
+        "mode": "0755",
+        "owner": "root",
+        "group": "root",
+    }
 }
 
 pkg_apt = {


### PR DESCRIPTION
manpage for sources.list says /etc/apt/keyrings is the correct location for keyrings manged by the system operator